### PR TITLE
Return decoded token instead of boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ Return: string, token of payload
 
 ### jwtInCookie.validateJwtToken(req)
 
-Returns whether request contains a valid JWT in its cookie (must be preceded by `jwtInCookie.configure`)
+Returns decoded token if request contains a valid JWT in its cookie (must be preceded by `jwtInCookie.configure`)
 
-Return: boolean
+Return: object
   
 `req` [express request object](https://expressjs.com/en/api.html#req)  
 
@@ -71,8 +71,8 @@ Return: encoded payload
 
 ### jwtInCookie.retrieveTokenFromCookie(req)
 
-Retrieves the JWT from the input request's cookie (must be preceded by `jwtInCookie.configure`)
+Retrieves decoded token from the input request's cookie (must be preceded by `jwtInCookie.configure`)
 
-Return: encoded token
+Return: decoded token
   
 `req` [express request object](https://expressjs.com/en/api.html#req)  

--- a/index.js
+++ b/index.js
@@ -81,22 +81,23 @@ const retrieveTokenFromCookie = function (req) {
     if (token === undefined || token === null) {
         throw new Error("JWT Token not defined in cookie");
     }
-    jwt.verify(token, instance.getSecret(), function (err, decoded) {
+    const decodedToken = jwt.verify(token, instance.getSecret(), function (err, decoded) {
         if (err) {
             throw new Error("Invalid JWT Token");
         }
+        return decoded
     });
-    return token;
+    return decodedToken;
 };
 exports.retrieveTokenFromCookie = retrieveTokenFromCookie;
 
 /**
- * Returns true if the request has a valid token in its cookie
+ * Returns decoded token if the request has a valid token in its cookie
  *
  * @param req
  * @returns {*}
  */
 exports.validateJwtToken = function (req) {
-    retrieveTokenFromCookie(req);
-    return true;
+    const decodedToken = retrieveTokenFromCookie(req);
+    return decodedToken;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jwt-in-cookie",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Wrapper around the functionality of jsonwebtoken to easily set and validate JWT tokens in express requests/responses",
   "homepage": "https://github.com/DavidStreid/jwt-in-cookie",
   "main": "index.js",


### PR DESCRIPTION
Allows for node/express middleware to attach decoded information to request without additional retrieval or verify.